### PR TITLE
Updates the compiler to 0.5.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ check-format:
 	dhall format --check --transitive package-set.dhall;
 	@echo checked dhall files are formatted
 ci: check-format
-	vessel verify --version 0.5.10 --moc-args="-Werror"
+	vessel verify --version 0.5.10

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ check-format:
 	dhall format --check --transitive package-set.dhall;
 	@echo checked dhall files are formatted
 ci: check-format
-	vessel verify --version 0.5.7
+	vessel verify --version 0.5.8

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ check-format:
 	dhall format --check --transitive package-set.dhall;
 	@echo checked dhall files are formatted
 ci: check-format
-	vessel verify --version 0.5.8
+	vessel verify --version 0.5.10 --moc-args="-Werror"


### PR DESCRIPTION
We can't fail CI on warnings just yet, but here's the CI output:
```
vessel verify --version 0.5.8
[INFO] Downloading tar-ball: "base"
[INFO] Verified "base" with output:
.vessel/base/dfx-0.6.23/src/Hash.mo:65.15-65.31: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Hash.mo:66.15-66.32: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Hash.mo:69.13-69.29: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Hash.mo:71.13-71.30: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Char.mo:24.5-24.50: warning [M0152], the arithmetic operation - on Word32 is deprecated, use -% instead
.vessel/base/dfx-0.6.23/src/Hash.mo:65.15-65.31: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Hash.mo:66.15-66.32: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Hash.mo:69.13-69.29: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Hash.mo:71.13-71.30: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Word8.mo:63.51-63.56: warning [M0152], the arithmetic operation + on Word8 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Word8.mo:66.51-66.56: warning [M0152], the arithmetic operation - on Word8 is deprecated, use -% instead
.vessel/base/dfx-0.6.23/src/Word8.mo:69.51-69.56: warning [M0152], the arithmetic operation * on Word8 is deprecated, use *% instead
.vessel/base/dfx-0.6.23/src/Word8.mo:80.51-80.57: warning [M0152], the arithmetic operation ** on Word8 is deprecated, use **% instead
.vessel/base/dfx-0.6.23/src/Word32.mo:63.54-63.59: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Word32.mo:66.54-66.59: warning [M0152], the arithmetic operation - on Word32 is deprecated, use -% instead
.vessel/base/dfx-0.6.23/src/Word32.mo:69.54-69.59: warning [M0152], the arithmetic operation * on Word32 is deprecated, use *% instead
.vessel/base/dfx-0.6.23/src/Word32.mo:80.54-80.60: warning [M0152], the arithmetic operation ** on Word32 is deprecated, use **% instead
.vessel/base/dfx-0.6.23/src/Random.mo:100.11-100.37: warning [M0152], the arithmetic operation + on Word8 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Random.mo:106.36-106.49: warning [M0152], the arithmetic operation + on Word8 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Random.mo:174.9-174.35: warning [M0152], the arithmetic operation + on Word8 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Random.mo:180.33-180.46: warning [M0152], the arithmetic operation + on Word8 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Char.mo:24.5-24.50: warning [M0152], the arithmetic operation - on Word32 is deprecated, use -% instead
.vessel/base/dfx-0.6.23/src/Word16.mo:63.54-63.59: warning [M0152], the arithmetic operation + on Word16 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Word16.mo:66.54-66.59: warning [M0152], the arithmetic operation - on Word16 is deprecated, use -% instead
.vessel/base/dfx-0.6.23/src/Word16.mo:69.54-69.59: warning [M0152], the arithmetic operation * on Word16 is deprecated, use *% instead
.vessel/base/dfx-0.6.23/src/Word16.mo:80.54-80.60: warning [M0152], the arithmetic operation ** on Word16 is deprecated, use **% instead
.vessel/base/dfx-0.6.23/src/Word64.mo:63.54-63.59: warning [M0152], the arithmetic operation + on Word64 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Word64.mo:66.54-66.59: warning [M0152], the arithmetic operation - on Word64 is deprecated, use -% instead
.vessel/base/dfx-0.6.23/src/Word64.mo:69.54-69.59: warning [M0152], the arithmetic operation * on Word64 is deprecated, use *% instead
.vessel/base/dfx-0.6.23/src/Word64.mo:80.54-80.60: warning [M0152], the arithmetic operation ** on Word64 is deprecated, use **% instead

[INFO] Downloading tar-ball: "matchers"
[INFO] Verified "matchers" with output:
.vessel/base/dfx-0.6.23/src/Hash.mo:65.15-65.31: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Hash.mo:66.15-66.32: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Hash.mo:69.13-69.29: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Hash.mo:71.13-71.30: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead

[INFO] Downloading tar-ball: "crud"
[INFO] Verified "crud" with output:
.vessel/base/dfx-0.6.23/src/Hash.mo:65.15-65.31: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Hash.mo:66.15-66.32: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Hash.mo:69.13-69.29: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/base/dfx-0.6.23/src/Hash.mo:71.13-71.30: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead

[INFO] Downloading tar-ball: "sha"
[INFO] Verified "sha" with output:
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:67.7-67.40: warning [M0152], the arithmetic operation + on Word64 is deprecated, use +% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:119.31-119.54: warning [M0152], the arithmetic operation * on Word64 is deprecated, use *% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:119.26-119.54: warning [M0152], the arithmetic operation - on Word64 is deprecated, use -% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:126.33-126.56: warning [M0152], the arithmetic operation * on Word32 is deprecated, use *% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:126.28-126.56: warning [M0152], the arithmetic operation - on Word32 is deprecated, use -% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:156.15-156.29: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:156.15-157.17: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:156.15-157.29: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:169.17-169.40: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:169.17-169.47: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:169.17-169.54: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:169.11-169.54: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:171.11-171.44: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:175.16-175.22: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:179.16-179.23: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:181.9-181.18: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:182.9-182.18: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:183.9-183.18: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:184.9-184.18: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:185.9-185.18: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:186.9-186.18: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:187.9-187.18: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:188.9-188.18: warning [M0152], the arithmetic operation + on Word32 is deprecated, use +% instead
.vessel/sha/e9962f37bd1e0d7e652f4051220884259361b85f/src/SHA256.mo:206.22-206.28: warning [M0152], the arithmetic operation - on Word32 is deprecated, use -% instead
```