### PR TITLE
Update motoko-crud to latest version

### DIFF
--- a/index/crud.dhall
+++ b/index/crud.dhall
@@ -5,6 +5,6 @@
 , authors = [ "Matthew Hammer" ]
 , owners = [ "matthewhammer" ]
 , repo = "https://github.com/matthewhammer/motoko-crud.git"
-, version = "c9bc6acbb6da81fc20d8ffec8063d9f6b4d01efd"
+, version = "0367a9a40eb708772df0662232a842c273a263e9"
 , dependencies = [ "base" ]
 }


### PR DESCRIPTION
The current motoko-crud version in vessel-package-set points to a commit from December 9, 2020.

The author @matthewhammer overrides the vessel-package-set crud version in his motoko-sequence example [manifest](https://github.com/matthewhammer/motoko-sequence/blob/e57b88cf4aa4852c7f66b9150692e256911c1425/example-package-set.dhall#L16). We should just update the vessel-package-set version to avoid overrides like this. (I need this as well.)