### PR TITLE
update to moc 0.6.29

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ check-format:
 	dhall type --file package-set.dhall;
 	@echo checked dhall files are well-typed.
 ci: check-format
-	vessel verify --version 0.6.21
+	vessel verify --version 0.6.22

--- a/index/base.dhall
+++ b/index/base.dhall
@@ -5,6 +5,6 @@
 , authors = [ "The DFINITY Language Team" ]
 , owners = [ "kritzcreek", "dfinity" ]
 , repo = "https://github.com/dfinity/motoko-base.git"
-, version = "494824a2787aee24ab4a5888aa519deb05ecfd60"
+, version = "238a73bd8ca501460987d4338f47dcbcaf2766e1"
 , dependencies = [] : List Text
 }


### PR DESCRIPTION
Not sure this is the right way to go about doing this but I would like to update moc to latest version. I saw prev commit to do something similar and would like to know if these changes are enough to accomplish that. 