### PR TITLE
Use commit hashes for all existing package versions

### DIFF
--- a/index/adapton.dhall
+++ b/index/adapton.dhall
@@ -5,6 +5,6 @@
 , authors = [ "Matthew Hammer" ]
 , owners = [ "matthewhammer" ]
 , repo = "https://github.com/matthewhammer/motoko-adapton.git"
-, version = "v0.1.1"
+, version = "d1b130fd930d8b498b66d2a2c6a45beea3f67c3a"
 , dependencies = [ "base" ]
 }

--- a/index/base32.dhall
+++ b/index/base32.dhall
@@ -4,6 +4,6 @@
 , authors = [ "flyq" ]
 , owners = [ "flyq" ]
 , repo = "https://github.com/flyq/motoko-base32.git"
-, version = "v0.1.1"
+, version = "067ac54e288f4cd7302be1f400bcddcce70f7d77"
 , dependencies = [ "base" ]
 }

--- a/index/easy-random.dhall
+++ b/index/easy-random.dhall
@@ -4,6 +4,6 @@
 , authors = [ "Fabio Biola" ]
 , owners = [ "neokree" ]
 , repo = "https://github.com/neokree/easy-random.git"
-, version = "v0.1.0"
+, version = "87acbe9565cb7fb4397c97d871bc8624a6bfb882"
 , dependencies = [ "base" ]
 }

--- a/index/icip.dhall
+++ b/index/icip.dhall
@@ -4,6 +4,6 @@
 , authors = [ "Inv Lo" ]
 , owners = [ "feliciss" ]
 , repo = "https://github.com/feliciss/icip.git"
-, version = "v1.2.0"
+, version = "3188b01d7ec5ef354c773c66197869cdce18c4b7"
 , dependencies = [ "base" ]
 }

--- a/index/iterext.dhall
+++ b/index/iterext.dhall
@@ -4,6 +4,6 @@
 , authors = [ "Timo Hanke" ]
 , owners = [ "timohanke" ]
 , repo = "https://github.com/timohanke/motoko-iterext"
-, version = "v2.0.0"
+, version = "6c05ff069e00eabdd2fc700d7457878d72dafaa9"
 , dependencies = [ "base" ]
 }

--- a/index/matchers.dhall
+++ b/index/matchers.dhall
@@ -4,6 +4,6 @@
 , authors = [ "Christoph Hegemann" ]
 , owners = [ "kritzcreek" ]
 , repo = "https://github.com/kritzcreek/motoko-matchers.git"
-, version = "v1.2.0"
+, version = "7f95f69ae9a399cedf161d90738db822f315c07e"
 , dependencies = [ "base" ]
 }

--- a/index/parsec.dhall
+++ b/index/parsec.dhall
@@ -4,6 +4,6 @@
 , authors = [ "Claudio Russo" ]
 , owners = [ "crusso" ]
 , repo = "https://github.com/crusso/mo-parsec.git"
-, version = "v1.0.0"
+, version = "6d84fe23245dac4c8c6c83f83349d972dd98289c"
 , dependencies = [ "base" ]
 }

--- a/index/pretty.dhall
+++ b/index/pretty.dhall
@@ -4,6 +4,6 @@
 , authors = [ "Christoph Hegemann" ]
 , owners = [ "kritzcreek" ]
 , repo = "https://github.com/kritzcreek/motoko-pretty.git"
-, version = "v0.1.0"
+, version = "73b81a2df1058396f0395d2d4a38ddcca4531142"
 , dependencies = [ "base" ]
 }

--- a/index/scc.dhall
+++ b/index/scc.dhall
@@ -4,6 +4,6 @@
 , authors = [ "Joachim Breitner" ]
 , owners = [ "nomeata" ]
 , repo = "https://github.com/nomeata/motoko-scc.git"
-, version = "v0.1.1"
+, version = "a6ddd4e688f75443674ad8ed24495fbeb103fc7b"
 , dependencies = [ "base" ]
 }

--- a/index/sequence.dhall
+++ b/index/sequence.dhall
@@ -4,6 +4,6 @@
 , authors = [ "Matthew Hammer" ]
 , owners = [ "matthewhammer" ]
 , repo = "https://github.com/matthewhammer/motoko-sequence.git"
-, version = "v0.1.1"
+, version = "e57b88cf4aa4852c7f66b9150692e256911c1425"
 , dependencies = [ "base" ]
 }

--- a/index/sha2.dhall
+++ b/index/sha2.dhall
@@ -4,6 +4,6 @@
 , authors = [ "Timo Hanke" ]
 , owners = [ "timohanke" ]
 , repo = "https://github.com/timohanke/motoko-sha2"
-, version = "v2.0.0"
+, version = "837682e5a503f200f6829081e41dd6c98b8d6bf9"
 , dependencies = [ "base", "iterext" ]
 }

--- a/index/sha224.dhall
+++ b/index/sha224.dhall
@@ -4,6 +4,6 @@
 , authors = [ "Enzo Haussecker", "flyq" ]
 , owners = [ "flyq" ]
 , repo = "https://github.com/flyq/motoko-sha224.git"
-, version = "v0.1.0"
+, version = "82e0aa1a77a8c0a2f98332b59ffc242d820e62cb"
 , dependencies = [ "base" ]
 }

--- a/index/splay.dhall
+++ b/index/splay.dhall
@@ -4,6 +4,6 @@
 , authors = [ "Yan Chen" ]
 , owners = [ "chenyan2002" ]
 , repo = "https://github.com/chenyan2002/motoko-splay.git"
-, version = "v0.1.0"
+, version = "f8e50749f9c4d7ccae99694c35310ac68945a225"
 , dependencies = [ "base" ]
 }


### PR DESCRIPTION
Fixes #51 by replacing all version tags with commit hashes. This is a temporary measure to improve security while we transition to a safer default versioning system for Vessel packages. 
