### PR TITLE
Bump `moc` to 0.9.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ check-format:
 	dhall type --file package-set.dhall;
 	@echo checked dhall files are well-typed.
 ci: check-format
-	vessel verify --version 0.9.0
+	vessel verify --version 0.9.1

--- a/index/base.dhall
+++ b/index/base.dhall
@@ -5,6 +5,6 @@
 , authors = [ "DFINITY Languages Team" ]
 , owners = [ "dfinity" ]
 , repo = "https://github.com/dfinity/motoko-base.git"
-, version = "4b858d9b76f3a48ab72b2fd467fa042e1903d148"
+, version = "f26c8064c70af292a4bf20bdea6225b9223ab0fe"
 , dependencies = [] : List Text
 }


### PR DESCRIPTION
@ggreif, I'm currently including `Principal.isController()` in the base library for this version. Let me know if you'd prefer for this to wait until the next release. 
