### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
     - uses: dhall-lang/setup-dhall@v4
+      with:
+        version: 1.42.0
     - name: "install tools"
       uses: ./.github/actions/install-tools
     - name: "verify"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
       - uses: dhall-lang/setup-dhall@v4
+        with:
+          version: 1.42.0
       - name: "install tools"
         uses: ./.github/actions/install-tools
       - name: "render package-set"


### PR DESCRIPTION
Manually specifies the Dhall version as a workaround for https://github.com/dhall-lang/dhall-haskell/issues/2564.