### PR TITLE
Bump `moc` to 0.11.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ check-format:
 	dhall type --file package-set.dhall;
 	@echo checked dhall files are well-typed.
 ci: check-format
-	vessel verify --version 0.11.1
+	vessel verify --version 0.11.2

--- a/index/base.dhall
+++ b/index/base.dhall
@@ -5,6 +5,6 @@
 , authors = [ "DFINITY Languages Team" ]
 , owners = [ "dfinity" ]
 , repo = "https://github.com/dfinity/motoko-base.git"
-, version = "6f49e5f877742b79e97ef1b6f226a7f905ba795c"
+, version = "cb79b657d9156f44bf7d195331af3aa88953467a"
 , dependencies = [] : List Text
 }


### PR DESCRIPTION
Catches up the Vessel package set to the previous Motoko version. Prerequisite for publishing the package-set for 0.11.3.