### PR TITLE
bumps `vessel` to 0.7.1

### DIFF
--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -3,7 +3,7 @@ description: 'Installs vessel'
 inputs:
   vessel_version:
     description: 'Vessel version to install'
-    default: '0.7.0'
+    default: '0.7.1'
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
vessel 0.7.0 had a bug that meant "verify" didn't actually compile any packages. After this bump CI should be meaningful again