### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-    - uses: dhall-lang/setup-dhall@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+    - uses: dhall-lang/setup-dhall@6b28be8f2912e67dd49585759e165ef53e4f7518 # v4.4.0
       with:
         version: 1.42.0
     - name: "install tools"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-      - uses: dhall-lang/setup-dhall@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: dhall-lang/setup-dhall@6b28be8f2912e67dd49585759e165ef53e4f7518 # v4.4.0
         with:
           version: 1.42.0
       - name: "install tools"
@@ -20,7 +20,7 @@ jobs:
         run: dhall resolve --file package-set.dhall | dhall > normalized
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -30,7 +30,7 @@ jobs:
           prerelease: false
       - name: Upload Release Asset
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -44,7 +44,7 @@ jobs:
           npm install --only=production
           npm run build ${{ github.ref }}
       - name: Upload Package Listing
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505 # releases/v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `actions/setup-node@v4` -> `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0`
  - Version: v4.4.0 | Latest: v6.3.0 | Release age: 37d
  - Commit: https://github.com/actions/setup-node/commit/49933ea5288caeca8642d1e84afbd3f7d6820020

- `dhall-lang/setup-dhall@v4` -> `dhall-lang/setup-dhall@6b28be8f2912e67dd49585759e165ef53e4f7518 # v4.4.0`
  - Version: v4.4.0 | Latest: v4 | Release age: 2203d
  - Commit: https://github.com/dhall-lang/setup-dhall/commit/6b28be8f2912e67dd49585759e165ef53e4f7518

- `actions/create-release@v1` -> `actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4`
  - Version: v1.1.4 | Latest: v1.1.4 | Release age: 2034d
  - Commit: https://github.com/actions/create-release/commit/0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e

- `actions/upload-release-asset@v1` -> `actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2`
  - Version: v1.0.2 | Latest: v1.0.2 | Release age: 2251d
  - Commit: https://github.com/actions/upload-release-asset/commit/e8f9f06c4b078e705bd2ea027f0926603fc9b4d5

- `JamesIves/github-pages-deploy-action@releases/v3` -> `JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505 # releases/v3`
  - Version: releases/v3 | Latest: v4.8.0 | Release age: 90d
  - Commit: https://github.com/JamesIves/github-pages-deploy-action/commit/132898c54c57c7cc6b80eb3a89968de8fc283505


### Files modified

- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`